### PR TITLE
feat: API documentation with swagger for existing endpoints

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/backend/src/main/java/com/nearrish/backend/security/ApiAuthenticationFilter.java
+++ b/backend/src/main/java/com/nearrish/backend/security/ApiAuthenticationFilter.java
@@ -44,6 +44,10 @@ public class ApiAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return path.startsWith("/api/public/") || path.startsWith("/api/auth/");
+        return path.startsWith("/api/public/") ||
+                path.startsWith("/api/auth/") ||
+                path.startsWith("/swagger-ui/") ||
+                path.startsWith("/v3/api-docs") ||
+                path.equals("/swagger-ui.html");
     }
 }

--- a/backend/src/main/java/com/nearrish/backend/security/OpenApiConfig.java
+++ b/backend/src/main/java/com/nearrish/backend/security/OpenApiConfig.java
@@ -1,0 +1,25 @@
+package com.nearrish.backend.security;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "customAuthHeader";
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement()
+                        .addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name("AUTH")
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)));
+    }
+}

--- a/backend/src/main/java/com/nearrish/backend/security/WebSecurityConfig.java
+++ b/backend/src/main/java/com/nearrish/backend/security/WebSecurityConfig.java
@@ -29,7 +29,11 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/public/**",
-                                "/api/auth/**").permitAll()
+                                "/api/auth/**",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(Customizer.withDefaults())


### PR DESCRIPTION
API documentation for existing endpoints

**Dependency**
- Added openAPI

**Security**
- Added bypasses so swagger can use the api endpoints without authentication

**Visit:**
`http://localhost:8080/swagger-ui/index.html`

<img width="1925" height="1041" alt="image" src="https://github.com/user-attachments/assets/f46a2fb0-9c77-4393-bf2e-6f8052cb9e77" />
